### PR TITLE
Add video duration

### DIFF
--- a/app/src/main/java/gun0912/tedimagepicker/sample/MainActivity.kt
+++ b/app/src/main/java/gun0912/tedimagepicker/sample/MainActivity.kt
@@ -13,6 +13,7 @@ import com.bumptech.glide.Glide
 import com.bumptech.glide.request.RequestOptions
 import gun0912.tedimagepicker.builder.TedImagePicker
 import gun0912.tedimagepicker.builder.TedRxImagePicker
+import gun0912.tedimagepicker.builder.type.MediaType
 import gun0912.tedimagepicker.sample.databinding.ActivityMainBinding
 import gun0912.tedimagepicker.sample.databinding.ItemImageBinding
 
@@ -29,12 +30,20 @@ class MainActivity : AppCompatActivity() {
         setNormalMultiButton()
         setRxSingleButton()
         setRxMultiButton()
+        setRxVideoButton()
     }
-
 
     private fun setNormalSingleButton() {
         binding.btnNormalSingle.setOnClickListener {
             TedImagePicker.with(this)
+                .start { uri -> showSingleImage(uri) }
+        }
+    }
+
+    private fun setRxVideoButton() {
+        binding.btnVideo.setOnClickListener {
+            TedImagePicker.with(this)
+                .mediaType(MediaType.VIDEO)
                 .start { uri -> showSingleImage(uri) }
         }
     }

--- a/app/src/main/java/gun0912/tedimagepicker/sample/MainActivity.kt
+++ b/app/src/main/java/gun0912/tedimagepicker/sample/MainActivity.kt
@@ -44,7 +44,7 @@ class MainActivity : AppCompatActivity() {
         binding.btnVideo.setOnClickListener {
             TedImagePicker.with(this)
                 .mediaType(MediaType.VIDEO)
-                .start { uri -> showSingleImage(uri) }
+                .startMultiImage { uri -> showSingleImage(uri.first()) }
         }
     }
 

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -37,6 +37,12 @@
             android:layout_height="wrap_content"
             android:text="Rx - Multi" />
 
+        <Button
+                android:id="@+id/btn_video"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="Video" />
+
         <ImageView
             android:id="@+id/iv_image"
             android:layout_width="wrap_content"

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
@@ -81,6 +81,7 @@ internal class MediaAdapter(
                     startZoomActivity(getItem(adapterPosition))
                 }
                 showZoom = false
+                showDuration = false
             }
 
         }

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
@@ -1,7 +1,9 @@
 package gun0912.tedimagepicker.adapter
 
 import android.app.Activity
+import android.media.MediaMetadataRetriever
 import android.net.Uri
+import android.text.format.DateUtils
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.core.app.ActivityOptionsCompat
@@ -15,6 +17,8 @@ import gun0912.tedimagepicker.databinding.ItemGalleryCameraBinding
 import gun0912.tedimagepicker.databinding.ItemGalleryMediaBinding
 import gun0912.tedimagepicker.model.Media
 import gun0912.tedimagepicker.zoom.TedImageZoomActivity
+import kotlinx.android.synthetic.main.item_gallery_media.view.*
+import java.io.File
 
 internal class MediaAdapter(
     private val activity: Activity,
@@ -89,8 +93,17 @@ internal class MediaAdapter(
                     selectedNumber = selectedUriList.indexOf(data.uri) + 1
                 }
 
-                showZoom =
-                    !isSelected && (builder.mediaType == MediaType.IMAGE) && builder.showZoomIndicator
+                showDuration = builder.mediaType == MediaType.VIDEO
+
+                if (showDuration) {
+                    val retriever = MediaMetadataRetriever()
+                    retriever.setDataSource(context, data.uri)
+
+                    val length = (Integer.parseInt(retriever.extractMetadata(MediaMetadataRetriever.METADATA_KEY_DURATION)) / 1000).toLong()
+                    itemView.video_duration_textview.text = "${DateUtils.formatElapsedTime(length)}"
+                }
+
+                showZoom = !isSelected && (builder.mediaType == MediaType.IMAGE) && builder.showZoomIndicator
             }
         }
 

--- a/tedimagepicker/src/main/res/layout/item_gallery_media.xml
+++ b/tedimagepicker/src/main/res/layout/item_gallery_media.xml
@@ -28,6 +28,10 @@
             name="showZoom"
             type="boolean" />
 
+        <variable
+            name="showDuration"
+            type="boolean" />
+
     </data>
 
     <FrameLayout
@@ -98,6 +102,33 @@
                     android:adjustViewBounds="true"
                     android:background="@color/ted_image_picker_zoom_background"
                     android:src="@drawable/ic_zoom_out_24dp" />
+            </FrameLayout>
+
+            <FrameLayout
+                    android:layout_width="0dp"
+                    android:layout_height="@dimen/ted_image_picker_zoom_size"
+                    android:id="@+id/view_video_duration"
+                    android:visibility="@{showDuration}"
+                    android:layout_marginBottom="@dimen/default_padding_small"
+                    android:layout_marginStart="@dimen/default_padding_xsmall"
+                    app:layout_constraintEnd_toEndOf="parent"
+                    app:layout_constraintBottom_toBottomOf="parent"
+                    app:layout_constraintStart_toEndOf="@id/view_zoom_out"
+            >
+
+                <TextView
+                        android:layout_width="wrap_content"
+                        android:layout_height="match_parent"
+                        android:id="@+id/video_duration_textview"
+                        android:background="@color/ted_image_picker_duration_background"
+                        android:text="0:00"
+                        android:layout_gravity="end"
+                        android:ellipsize="marquee"
+                        android:marqueeRepeatLimit="marquee_forever"
+                        android:textColor="@color/white"
+                        android:paddingStart="@dimen/default_padding_small"
+                        android:paddingEnd="@dimen/default_padding_small"/>
+
             </FrameLayout>
         </androidx.constraintlayout.widget.ConstraintLayout>
     </FrameLayout>

--- a/tedimagepicker/src/main/res/values/colors.xml
+++ b/tedimagepicker/src/main/res/values/colors.xml
@@ -25,5 +25,5 @@
 
     <color name="ted_image_picker_zoom_background">#defafafa</color>
 
-
+    <color name="ted_image_picker_duration_background">#78000000</color>
 </resources>


### PR DESCRIPTION
This branch adds the duration of a video to the picker media item. It only shows if it's media type is `MediaType.VIDEO` and is loaded using the `MediaMetadataRetriever`.