### PR TITLE
Fix scoped storage permission for API level 30

### DIFF
--- a/tedimagepicker/src/main/AndroidManifest.xml
+++ b/tedimagepicker/src/main/AndroidManifest.xml
@@ -1,10 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     package="gun0912.tedimagepicker">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
-        android:maxSdkVersion="28"
-        tools:ignore="ScopedStorage" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <queries>
         <intent>

--- a/tedimagepicker/src/main/AndroidManifest.xml
+++ b/tedimagepicker/src/main/AndroidManifest.xml
@@ -1,7 +1,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="gun0912.tedimagepicker">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
     <queries>
         <intent>

--- a/tedimagepicker/src/main/AndroidManifest.xml
+++ b/tedimagepicker/src/main/AndroidManifest.xml
@@ -1,7 +1,10 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     package="gun0912.tedimagepicker">
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage" />
 
     <queries>
         <intent>

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
@@ -7,6 +7,7 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
+import android.os.Build
 import android.os.Parcelable
 import androidx.annotation.AnimRes
 import androidx.annotation.ColorRes
@@ -91,7 +92,7 @@ open class TedImagePickerBaseBuilder<out B : TedImagePickerBaseBuilder<B>>(
     protected fun startInternal(context: Context) {
         checkPermission(context)
             .subscribe({ permissionResult ->
-                if (permissionResult.isGranted) {
+                if (permissionResult.isGranted || Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                     startActivity(context)
                 }
             }, { throwable -> onErrorListener?.onError(throwable) })

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
@@ -98,7 +98,7 @@ open class TedImagePickerBaseBuilder<out B : TedImagePickerBaseBuilder<B>>(
     }
 
     private fun checkPermission(context: Context) = TedRx2Permission.with(context)
-        .setPermissions(Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        .setPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
         .request()
 
     private fun startActivity(context: Context) {

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
@@ -7,7 +7,6 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
-import android.os.Build
 import android.os.Parcelable
 import androidx.annotation.AnimRes
 import androidx.annotation.ColorRes
@@ -92,7 +91,7 @@ open class TedImagePickerBaseBuilder<out B : TedImagePickerBaseBuilder<B>>(
     protected fun startInternal(context: Context) {
         checkPermission(context)
             .subscribe({ permissionResult ->
-                if (permissionResult.isGranted || Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                if (permissionResult.isGranted) {
                     startActivity(context)
                 }
             }, { throwable -> onErrorListener?.onError(throwable) })


### PR DESCRIPTION
- when applying `android:maxSdkVersion="28"` for `WRITE_EXTERNAL_STORAGE`, activity cannot be started.