### PR TITLE
Android 28 이하 버전 기기 스토리지 접근 호환성 유지 

### DIFF
--- a/tedimagepicker/src/main/AndroidManifest.xml
+++ b/tedimagepicker/src/main/AndroidManifest.xml
@@ -1,7 +1,11 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
     package="gun0912.tedimagepicker">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage" />
 
     <queries>
         <intent>

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
@@ -7,11 +7,13 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.ActivityInfo
 import android.net.Uri
+import android.os.Build
 import android.os.Parcelable
 import androidx.annotation.AnimRes
 import androidx.annotation.ColorRes
 import androidx.annotation.DrawableRes
 import androidx.annotation.StringRes
+import com.gun0912.tedpermission.TedPermissionResult
 import com.gun0912.tedpermission.rx2.TedPermission
 import com.tedpark.tedonactivityresult.rx2.TedRxOnActivityResult
 import gun0912.tedimagepicker.R
@@ -25,6 +27,7 @@ import gun0912.tedimagepicker.builder.type.ButtonGravity
 import gun0912.tedimagepicker.builder.type.MediaType
 import gun0912.tedimagepicker.builder.type.SelectType
 import gun0912.tedimagepicker.util.ToastUtil
+import io.reactivex.Single
 import kotlinx.parcelize.IgnoredOnParcel
 import kotlinx.parcelize.Parcelize
 
@@ -102,9 +105,19 @@ open class TedImagePickerBaseBuilder<out B : TedImagePickerBaseBuilder<B>>(
             }, { throwable -> onErrorListener?.onError(throwable) })
     }
 
-    private fun checkPermission(context: Context) = TedPermission.create()
-        .setPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
-        .request()
+    private fun checkPermission(context: Context): Single<TedPermissionResult> {
+        val permissions = if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            arrayOf(
+                Manifest.permission.READ_EXTERNAL_STORAGE,
+                Manifest.permission.WRITE_EXTERNAL_STORAGE,
+            )
+        } else {
+            arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE)
+        }
+        return TedPermission.create()
+            .setPermissions(*permissions)
+            .request()
+    }
 
     private fun startActivity(context: Context) {
         TedImagePickerActivity.getIntent(context, this)

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/GalleryUtil.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/GalleryUtil.kt
@@ -40,9 +40,18 @@ internal class GalleryUtil {
                     }
 
                     val sortOrder = "$INDEX_DATE_ADDED DESC"
-                    val projection =
-                        arrayOf(INDEX_MEDIA_ID, INDEX_MEDIA_URI, albumName, INDEX_DATE_ADDED)
-                    val selection = MediaStore.Images.Media.SIZE + " > 0"
+
+                    val projection = arrayOf(
+                        INDEX_MEDIA_ID,
+                        INDEX_MEDIA_URI,
+                        albumName,
+                        INDEX_DATE_ADDED
+                    )
+                    val selection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+                        MediaStore.Images.Media.SIZE + " > 0"
+                    } else {
+                        null
+                    }
                     val cursor =
                         context.contentResolver.query(uri, projection, selection, null, sortOrder)
                     val albumList: List<Album> = cursor?.let {


### PR DESCRIPTION
- 28버전 이하 기기에서만 `WRITE_EXTERNAL_STORAGE` 권한을 요구하도록 변경했습니다.
- 기존 `MedaiUtil`의 `getMediaUri`에서 분기처리하여 Q 버전 미만 기기에서 파일로 처리하는 로직 제거 및 분기 로직을 제거했습니다.
- 28버전 이하 기기에서 `cursor.query`의 `selection` 파라미터 때문에 갤러리 이미지를 제대로 불러오지 못해서 `selection` 파라미터를 분기 처리하였습니다.