### PR TITLE
Allow custom functionality on the TedImagePickerActivity by opening some clases and funciones

### DIFF
--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
@@ -48,7 +48,7 @@ import java.util.concurrent.TimeUnit
 import kotlin.collections.ArrayList
 
 
-internal class TedImagePickerActivity : AppCompatActivity() {
+open class TedImagePickerActivity : AppCompatActivity() {
 
     private lateinit var binding: ActivityTedImagePickerBinding
     private val albumAdapter by lazy { AlbumAdapter(builder) }
@@ -268,7 +268,7 @@ internal class TedImagePickerActivity : AppCompatActivity() {
     }
 
     @SuppressLint("CheckResult")
-    private fun onCameraTileClick() {
+    open fun onCameraTileClick() {
         val (cameraIntent, uri) = MediaUtil.getMediaIntentUri(
             this@TedImagePickerActivity,
             builder.mediaType,

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
@@ -106,8 +106,12 @@ open class TedImagePickerBaseBuilder<out B : TedImagePickerBaseBuilder<B>>(
         .setPermissions(Manifest.permission.READ_EXTERNAL_STORAGE)
         .request()
 
+    private open fun getIntent(context: Context): Intent {
+        // allow to use a custom activity intent
+        return TedImagePickerActivity.getIntent(context, this)
+    }
     private fun startActivity(context: Context) {
-        TedImagePickerActivity.getIntent(context, this)
+        getIntent(context, this)
             .run {
                 TedRxOnActivityResult.with(context).startActivityForResult(this)
             }.run {

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedRxImagePicker.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedRxImagePicker.kt
@@ -19,7 +19,7 @@ class TedRxImagePicker {
     }
 
     @SuppressLint("ParcelCreator")
-    class Builder(private val contextWeakReference: WeakReference<Context>) :
+    open class Builder(private val contextWeakReference: WeakReference<Context>) :
         TedImagePickerBaseBuilder<Builder>() {
 
         fun start(): Single<Uri> =


### PR DESCRIPTION
For some applications the default camera intent is not feasible, those projects, will need extra control on the camera (image recognition, video annotation, resolution adjustments, filtering, etc), so while adding custom buttons for **TedImagePicker** can be a reasonable solution, to allow the extension of the already built clases can be a faster way to solve this issue.

How:
1. By overriding the **TedImagePicker.Bundle**, then a new function **getIntent(context)** will return the custom intent discussed on #2
2. A custom **TedImagePickerActivity** with an open **onCameraTileClick** that will allow the call of a custom camera activity
3. The override of the onActivityResult to get the images, and then call **loadMedia(true)** and **onMediaClick(uri)**