### PR TITLE
Modify ToastUtil context cast

### DIFF
--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/TedImagePickerContentProvider.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/TedImagePickerContentProvider.kt
@@ -3,12 +3,13 @@ package gun0912.tedimagepicker.util
 import android.app.Application
 import android.content.ContentProvider
 import android.content.ContentValues
+import android.content.Context
 import android.database.Cursor
 import android.net.Uri
 
 class TedImagePickerContentProvider : ContentProvider() {
     override fun onCreate(): Boolean {
-        ToastUtil.context = context as Application
+        ToastUtil.context = context as Context
         return true
     }
 

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/TedImagePickerContentProvider.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/TedImagePickerContentProvider.kt
@@ -1,6 +1,5 @@
 package gun0912.tedimagepicker.util
 
-import android.app.Application
 import android.content.ContentProvider
 import android.content.ContentValues
 import android.content.Context


### PR DESCRIPTION
_java.lang.RuntimeException_ is raised when sample application is wrapped with Microsoft Intune (#103). 

TedImagePickerContentProvider is trying to cast context to Application which is not compatible in case of wrapped app. I suggest we use Context cast instead.