### PR TITLE
Video Type permission fix

### DIFF
--- a/tedimagepicker/src/main/AndroidManifest.xml
+++ b/tedimagepicker/src/main/AndroidManifest.xml
@@ -1,7 +1,8 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" xmlns:tools="http://schemas.android.com/tools"
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="gun0912.tedimagepicker">
 
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission
         android:name="android.permission.READ_EXTERNAL_STORAGE"
         android:maxSdkVersion="32" />

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/builder/TedImagePickerBaseBuilder.kt
@@ -107,7 +107,10 @@ open class TedImagePickerBaseBuilder<out B : TedImagePickerBaseBuilder<B>>(
 
     private fun checkPermission(): Single<TedPermissionResult> {
         val permission = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-            Manifest.permission.READ_MEDIA_IMAGES
+            when(mediaType){
+                MediaType.IMAGE -> Manifest.permission.READ_MEDIA_IMAGES
+                MediaType.VIDEO -> Manifest.permission.READ_MEDIA_VIDEO
+            }
         } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
             Manifest.permission.READ_EXTERNAL_STORAGE
         } else {


### PR DESCRIPTION
If media type is `VIDEO`, image picker will request video permission
- https://developer.android.com/about/versions/13/behavior-changes-13?#granular-media-permissions