### PR TITLE
Use [duration] column for only video type

### DIFF
--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/GalleryUtil.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/util/GalleryUtil.kt
@@ -68,13 +68,16 @@ internal class GalleryUtil {
         private fun getAllMediaList(context: Context, queryMediaType: QueryMediaType): List<Media> {
             val sortOrder = "$INDEX_DATE_ADDED DESC"
 
-            val projection = arrayOf(
+            val projection = mutableListOf(
                 INDEX_MEDIA_ID,
                 INDEX_MEDIA_URI,
                 INDEX_ALBUM_NAME,
                 INDEX_DATE_ADDED,
-                INDEX_DURATION,
-            )
+            ).apply {
+                if (queryMediaType == QueryMediaType.VIDEO) {
+                    add(INDEX_DURATION)
+                }
+            }.toTypedArray()
             val selection = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
                 MediaStore.Images.Media.SIZE + " > 0"
             } else {
@@ -107,12 +110,13 @@ internal class GalleryUtil {
                     val albumName = getString(getColumnIndexOrThrow(INDEX_ALBUM_NAME))
                     val mediaUri = getMediaUri(queryMediaType)
                     val datedAddedSecond = getLong(getColumnIndexOrThrow(INDEX_DATE_ADDED))
-                    val duration = getLong(getColumnIndexOrThrow(INDEX_DURATION))
                     when (queryMediaType) {
                         QueryMediaType.IMAGE ->
                             Media.Image(albumName, mediaUri, datedAddedSecond)
-                        QueryMediaType.VIDEO ->
+                        QueryMediaType.VIDEO -> {
+                            val duration = getLong(getColumnIndexOrThrow(INDEX_DURATION))
                             Media.Video(albumName, mediaUri, datedAddedSecond, duration)
+                        }
                     }
                 }
             } catch (exception: Exception) {


### PR DESCRIPTION
Fix this issue
```kotlin
Caused by: android.database.sqlite.SQLiteException: no such column: duration (code 1 SQLITE_ERROR):
```
- Cause: Low OS version can not recognize duration column for image type
- Solution: Use [duration] column for only video type