### PR TITLE
🚀 Performance Enhancement: Faster Initialization for Pre-Selected Images

### DIFF
--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
@@ -108,7 +108,7 @@ internal class TedImagePickerActivity
         }
     }
 
-    private fun setupWindowInsets(){
+    private fun setupWindowInsets() {
         val view = findViewById<View>(android.R.id.content)
         ViewCompat.setOnApplyWindowInsetsListener(view) { v, insets ->
             val systemBars =
@@ -183,15 +183,23 @@ internal class TedImagePickerActivity
                 albumAdapter.replaceAll(albumList)
                 setSelectedAlbum(selectedPosition)
                 if (!isRefresh) {
-                    setSelectedUriList(builder.selectedUriList)
+                    initSelectedUriList(builder.selectedUriList)
                 }
                 binding.layoutContent.rvMedia.visibility = View.VISIBLE
 
             }
     }
 
-    private fun setSelectedUriList(uriList: List<Uri>?) =
-        uriList?.forEach { uri: Uri -> onMultiMediaClick(uri) }
+    private fun initSelectedUriList(uriList: List<Uri>?) {
+        uriList ?: return
+        isUpdatingSelection = true
+
+        mediaAdapter.initSelectedUriList(uriList)
+        uriList.forEach { selectionTracker.select(it) }
+        updateSelectedUI()
+
+        isUpdatingSelection = false
+    }
 
     private fun setSavedInstanceState(savedInstanceState: Bundle?) {
 

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
@@ -30,6 +30,13 @@ internal class MediaAdapter(
     override fun getHeaderViewHolder(parent: ViewGroup) = CameraViewHolder(parent)
     override fun getItemViewHolder(parent: ViewGroup) = ImageViewHolder(parent)
 
+    fun initSelectedUriList(uris: List<Uri>) {
+        selectedUriList.clear()
+        selectedUriList.addAll(uris)
+        onMediaAddListener?.invoke()
+        notifyItemRangeInserted(headerCount, items.size)
+    }
+
     fun toggleMediaSelect(uri: Uri) {
         if (selectedUriList.contains(uri)) {
             removeMedia(uri)


### PR DESCRIPTION
## 📝 Problem

When initializing the picker with a **pre-selected** list of images, the library previously:

* Iterated each `Uri` and invoked the same selection function used for **manual** single-item selection.
* Triggered **individual UI updates** per image.
* Re-executed **redundant selection logic** for every item.
* Caused **noticeable delay** opening the picker with large lists (e.g., 60–70+ images), leading to a poor UX.

This approach was acceptable for small sets (5–10 images) but became a bottleneck for larger lists.

---

## ✨ Solution

Introduce a **dedicated initialization path** that handles bulk selection efficiently:

* **Batch processing:** Initialize the entire selected list **at once** instead of item-by-item.
* **Optimized UI updates:** Minimize redundant refreshes during initialization.
* **Improved UX:** Significantly faster startup, especially with large pre-selected lists.

---

## 🔧 Technical Changes

* Added `initSelectedUriList()` in `MediaAdapter` for efficient **bulk initialization**.
* Updated `TedImagePickerActivity` to use the new initialization approach.
* **Separated** initialization logic from per-item selection logic.
* Maintained **backward compatibility** with existing public APIs.

---

## 🧪 Testing

* [x] Small lists: **1–10** images
* [x] Medium lists: **20–50** images
* [x] Large lists: **60–100** images
* [x] Verified **backward compatibility**
* [x] Confirmed **UI state consistency** after initialization

---

## 💡 Benefits

* **Faster startup:** Dramatically reduced initialization time for large pre-selected sets.
* **Better UX:** Picker appears immediately without noticeable delays.
* **Scalable:** Gains increase with the number of pre-selected images.
* **Maintainable:** Cleaner separation between initialization and selection logic.

---

## 🔄 Migration

No action required.
This change is **fully backward compatible**—existing integrations automatically benefit from the performance improvements.
