### PR TITLE
Fix: Improve removedItems determination logic

### DIFF
--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
@@ -353,7 +353,11 @@ internal class TedImagePickerActivity
         val lastSelectedItems = mediaAdapter.selectedUriList.toList()
 
         val addedItems = newSelectedItems - lastSelectedItems.toSet()
-        val removedItems = lastSelectedItems - newSelectedItems.toSet()
+        val currentAlbumUris = mediaAdapter.getMediaUris()
+        val removedItems = lastSelectedItems.filter { uri ->
+            currentAlbumUris.contains(uri) && !newSelectedItems.contains(uri)
+        }
+
         val updatedPositions = mutableSetOf<Int>()
 
         // add items

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
@@ -77,6 +77,8 @@ internal class MediaAdapter(
         }
     }
 
+    fun getMediaUris(): List<Uri> = items.map { it.uri }
+
     @SuppressLint("ClickableViewAccessibility")
     inner class ImageViewHolder(parent: ViewGroup) :
         BaseViewHolder<ItemGalleryMediaBinding, Media>(parent, R.layout.item_gallery_media) {


### PR DESCRIPTION
#150 


## 🐛 Problem

When switching albums in the image picker, the `removedItems` calculation was incorrectly including items that don't exist in the current album. This was causing issues with selection state management when navigating between different albums.

The previous logic used a simple set difference operation:
```kotlin
val removedItems = lastSelectedItems - newSelectedItems.toSet()
```

This approach would mark items as "removed" even when they were simply not present in the current album, leading to incorrect selection state updates.

## ✅ Solution

Enhanced the `removedItems` determination logic to only consider items that are actually present in the current album:

```kotlin
val currentAlbumUris = mediaAdapter.getMediaUris()
val removedItems = lastSelectedItems.filter { uri ->
    currentAlbumUris.contains(uri) && !newSelectedItems.contains(uri)
}
```

### Changes Made

1. **Added `getMediaUris()` method to `MediaAdapter`**
   - Returns a list of all media URIs in the current album
   - Provides a way to check if a URI exists in the current view

2. **Updated removedItems logic in `TedImagePickerActivity`**
   - Now filters `lastSelectedItems` to only include URIs that exist in the current album
   - Only marks items as "removed" if they are both present in current album AND not in the new selection

## 🧪 Test Scenario

1. Select multiple images from Album A
2. Switch to Album B
3. Modify selection in Album B
4. Switch back to Album A

**Before**: Items from Album A would be incorrectly processed as "removed" when switching to Album B
**After**: Only items actually deselected within the current album are processed as removed

## 📁 Files Changed

- `tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt`
- `tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt`

## 🎯 Impact

- Fixes selection state management when switching between albums
- Improves performance by avoiding unnecessary UI updates for items not in current view
- Maintains backward compatibility with existing API