### PR TITLE
 Fix: Resolve selected media disappearing when switching albums

### DIFF
--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/TedImagePickerActivity.kt
@@ -352,8 +352,15 @@ internal class TedImagePickerActivity
         val newSelectedItems = selectionTracker.selection.toList()
         val lastSelectedItems = mediaAdapter.selectedUriList.toList()
 
-        val addedItems = newSelectedItems - lastSelectedItems.toSet()
-        val currentAlbumUris = mediaAdapter.getMediaUris()
+        // Consider only media items in the current album
+        val currentAlbumUris = albumAdapter.getItem(selectedPosition).mediaUris.map { it.uri }
+        
+        // Items added in SelectionTracker (only those in current album)
+        val addedItems = newSelectedItems.filter { uri ->
+            currentAlbumUris.contains(uri) && !lastSelectedItems.contains(uri)
+        }
+        
+        // Items removed in SelectionTracker (only those in current album)
         val removedItems = lastSelectedItems.filter { uri ->
             currentAlbumUris.contains(uri) && !newSelectedItems.contains(uri)
         }
@@ -560,11 +567,39 @@ internal class TedImagePickerActivity
             return
         }
 
+        // Backup current selection state when album changes
+        val currentSelectedUris = mediaAdapter.selectedUriList.toList()
+        isUpdatingSelection = true
+        
         binding.selectedAlbum = album
         this.selectedPosition = selectedPosition
         albumAdapter.setSelectedAlbum(album)
         mediaAdapter.replaceAll(album.mediaUris)
+        
+        // Restore previously selected items in new album
+        if (currentSelectedUris.isNotEmpty() && ::selectionTracker.isInitialized) {
+            restoreSelectionAfterAlbumChange(album.mediaUris, currentSelectedUris)
+        }
+        
+        isUpdatingSelection = false
         binding.layoutContent.rvMedia.layoutManager?.scrollToPosition(0)
+    }
+
+    private fun restoreSelectionAfterAlbumChange(albumMediaUris: List<Media>, selectedUris: List<Uri>) {
+        // Filter only selected items that exist in the new album
+        val urisInCurrentAlbum = selectedUris.filter { uri ->
+            albumMediaUris.any { it.uri == uri }
+        }
+        
+        // MediaAdapter maintains the entire selection list
+        mediaAdapter.selectedUriList.clear()
+        mediaAdapter.selectedUriList.addAll(selectedUris)
+        
+        // SelectionTracker selects only items in current album
+        selectionTracker.clearSelection()
+        urisInCurrentAlbum.forEach { selectionTracker.select(it) }
+        
+        updateSelectedUI()
     }
 
     private fun setupListener() {

--- a/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
+++ b/tedimagepicker/src/main/java/gun0912/tedimagepicker/adapter/MediaAdapter.kt
@@ -77,8 +77,6 @@ internal class MediaAdapter(
         }
     }
 
-    fun getMediaUris(): List<Uri> = items.map { it.uri }
-
     @SuppressLint("ClickableViewAccessibility")
     inner class ImageViewHolder(parent: ViewGroup) :
         BaseViewHolder<ItemGalleryMediaBinding, Media>(parent, R.layout.item_gallery_media) {


### PR DESCRIPTION
fix #150 

## 📋 Summary

This PR provides a comprehensive solution to the issue where selected media items would disappear when users switch between different albums in the image picker.

## 🐛 Problem Description

**Original Issue:** [#150](https://github.com/ParkSangGwon/TedImagePicker/issues/150)

Users reported that when selecting media items in one album and then switching to another album, the previously selected items would disappear, and the selection counter would reset to zero. This behavior was confusing and made multi-album selection workflow nearly impossible.

**Previous Attempt:** [PR #151](https://github.com/ParkSangGwon/TedImagePicker/pull/151)

The previous fix only addressed the `removedItems` calculation logic, which provided a partial solution but didn't solve the fundamental issue of selection state management across album changes.

## 🔧 Root Cause Analysis

The core problem was in the selection state management during album transitions:

1. **Selection State Loss**: When switching albums, the `SelectionTracker` would lose track of previously selected items
2. **Inconsistent State**: `MediaAdapter.selectedUriList` and `SelectionTracker` selection were not properly synchronized
3. **Missing Restoration Logic**: No mechanism existed to restore selections when returning to previously visited albums

## ✨ Solution Implementation

### Key Changes

1. **Selection State Backup & Restore System**
   ```kotlin
   private fun setSelectedAlbum(selectedPosition: Int) {
       // Backup current selection state when album changes
       val currentSelectedUris = mediaAdapter.selectedUriList.toList()
       isUpdatingSelection = true
       
       // ... album switching logic ...
       
       // Restore previously selected items in new album
       if (currentSelectedUris.isNotEmpty() && ::selectionTracker.isInitialized) {
           restoreSelectionAfterAlbumChange(album.mediaUris, currentSelectedUris)
       }
   }
   ```

2. **Smart Selection Restoration**
   ```kotlin
   private fun restoreSelectionAfterAlbumChange(albumMediaUris: List<Media>, selectedUris: List<Uri>) {
       // Filter only selected items that exist in the new album
       val urisInCurrentAlbum = selectedUris.filter { uri ->
           albumMediaUris.any { it.uri == uri }
       }
       
       // MediaAdapter maintains the entire selection list
       mediaAdapter.selectedUriList.clear()
       mediaAdapter.selectedUriList.addAll(selectedUris)
       
       // SelectionTracker selects only items in current album
       selectionTracker.clearSelection()
       urisInCurrentAlbum.forEach { selectionTracker.select(it) }
   }
   ```

3. **Improved Sync Logic**
   - Enhanced `syncSelectedListWithTracker()` to better handle album-specific selections
   - Added proper filtering to consider only current album items during sync operations

### Architecture Improvements

- **Dual-Layer Selection Management**: 
  - `MediaAdapter.selectedUriList`: Maintains global selection state across all albums
  - `SelectionTracker`: Handles UI selection state for current album only

- **Cross-Album Selection Persistence**: Selected items are now maintained when switching between albums and properly restored when returning to previously visited albums

## 🧪 Test Scenarios

1. ✅ Select items in Album A → Switch to Album B → Items remain selected in counter
2. ✅ Select items in Album A → Select different items in Album B → Both selections persist
3. ✅ Select items in Album A → Switch to Album B → Return to Album A → Previous selections restored
4. ✅ Maximum selection limit respected across all albums
5. ✅ Selection counter displays correct total across albums

## 📊 Impact

- **User Experience**: Seamless multi-album selection workflow
- **Performance**: Optimized selection tracking with minimal overhead
- **Backward Compatibility**: No breaking changes to existing API
- **Reliability**: Consistent selection state management across all scenarios

## 🔄 Migration Notes

This fix is fully backward compatible. No changes required for existing implementations.

---

**Related Issues:** 
- Fixes #150 
- Improves upon #151

**Testing:** Manual testing performed across various album switching scenarios with different selection combinations.